### PR TITLE
Update dependencies to platform version 1.22.6

### DIFF
--- a/crd-handler-clouddriver/crd-handler-clouddriver.gradle
+++ b/crd-handler-clouddriver/crd-handler-clouddriver.gradle
@@ -15,7 +15,7 @@ targetCompatibility = 1.8
 repositories {
   mavenCentral()
   jcenter()
-  maven { url "http://dl.bintray.com/spinnaker/spinnaker/" }
+  maven { url "https://spinnaker-releases.bintray.com/jars" }
 
   // TODO: remove once we aren't using the Google product release version
   // for Clouddriver.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+spinnakerRelease=1.22.6
 org.gradle.parallel=true
 
 spinnakerGradleVersion=8.0.4
@@ -5,5 +6,5 @@ pf4jVersion=3.2.0
 korkVersion=7.59.0
 
 # TODO: switch to a real Clouddriver release.
-clouddriverVersion=6.9.0-20200521133338
+clouddriverVersion=6.11.2-20201201112312
 kotlinVersion=1.3.50


### PR DESCRIPTION
Event
```
{
  "branchName": "release-1.22.x",
  "createTag": true,
  "dependencyUpdates": [
    {
      "depName": "clouddriver",
      "depVersion": "6.11.2-20201201112312"
    }
  ],
  "hasDependencyUpdates": true,
  "newGradleProperties": "spinnakerRelease=1.22.6\norg.gradle.parallel=true\n\nspinnakerGradleVersion=8.0.4\npf4jVersion=3.2.0\nkorkVersion=7.59.0\n\n# TODO: switch to a real Clouddriver release.\nclouddriverVersion=6.11.2-20201201112312\nkotlinVersion=1.3.50",
  "orgName": "spinnaker-plugin-examples",
  "platformVersion": "1.22.6",
  "repoId": "MDEwOlJlcG9zaXRvcnkyNjcwNjgyMDU=",
  "repoName": "kubernetesCRDHandler"
}
```