### PR TITLE
Update dependencies to platform version 1.28.0

### DIFF
--- a/crd-handler-clouddriver/crd-handler-clouddriver.gradle
+++ b/crd-handler-clouddriver/crd-handler-clouddriver.gradle
@@ -15,7 +15,7 @@ targetCompatibility = 1.8
 repositories {
   mavenCentral()
   jcenter()
-  maven { url "http://dl.bintray.com/spinnaker/spinnaker/" }
+  maven { url "https://spinnaker-releases.bintray.com/jars" }
 
   // TODO: remove once we aren't using the Google product release version
   // for Clouddriver.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
+spinnakerRelease=1.28.0
 org.gradle.parallel=true
 
 spinnakerGradleVersion=8.0.4
 pf4jVersion=3.2.0
-korkVersion=7.61.2
+korkVersion=7.136.0
 
 # TODO: switch to a real Clouddriver release.
-clouddriverVersion=6.9.0-20200521133338
+clouddriverVersion=5.76.2
 kotlinVersion=1.3.50


### PR DESCRIPTION
Event
```
{
  "branchName": "release-1.28.x",
  "createTag": true,
  "dependencyUpdates": [
    {
      "depName": "clouddriver",
      "depVersion": "5.76.2"
    },
    {
      "depName": "kork",
      "depVersion": "7.136.0"
    }
  ],
  "hasDependencyUpdates": true,
  "newGradleProperties": "spinnakerRelease=1.28.0\norg.gradle.parallel=true\n\nspinnakerGradleVersion=8.0.4\npf4jVersion=3.2.0\nkorkVersion=7.136.0\n\n# TODO: switch to a real Clouddriver release.\nclouddriverVersion=5.76.2\nkotlinVersion=1.3.50",
  "orgName": "spinnaker-plugin-examples",
  "platformVersion": "1.28.0",
  "repoId": "MDEwOlJlcG9zaXRvcnkyNjcwNjgyMDU=",
  "repoName": "kubernetesCRDHandler"
}
```